### PR TITLE
ParserAbstract: add missing '*' to the phpdoc

### DIFF
--- a/lib/PhpParser/ParserAbstract.php
+++ b/lib/PhpParser/ParserAbstract.php
@@ -60,7 +60,7 @@ abstract class ParserAbstract implements Parser
 
     /** @var int[] Map of states to a displacement into the $action table. The corresponding action for this
      *             state/symbol pair is $action[$actionBase[$state] + $symbol]. If $actionBase[$state] is 0, the
-                   action is defaulted, i.e. $actionDefault[$state] should be used instead. */
+     *             action is defaulted, i.e. $actionDefault[$state] should be used instead. */
     protected $actionBase;
     /** @var int[] Table of actions. Indexed according to $actionBase comment. */
     protected $action;


### PR DESCRIPTION
Otherwise, it's somewhat incompatible with the phpdoc definition.

> In the case where a DocComment spans multiple lines, every line MUST start with an asterisk (*)
   that SHOULD be aligned with the first asterisk of the opening clause.
